### PR TITLE
Release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Use next sections inside each different action entry to describe changes on each
 
 ### deploy-platform
 
+## [2.2.1] - 2023-06-07
+
+### deploy-platform
+
 ### Fixed
 
 * fix: Increase ARTIFACT_AVAILABLE timeout to 60 seconds in order to make it compatible with the current request interval default value (CROSS-1093)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Use next sections inside each different action entry to describe changes on each
 
 ### deploy-platform
 
-### Fixed
+#### Fixed
 
 * fix: Increase ARTIFACT_AVAILABLE timeout to 60 seconds in order to make it compatible with the current request interval default value (CROSS-1093)
 


### PR DESCRIPTION
# Release v2.2.1

## deploy-platform

#### Fixed

* fix: Increase ARTIFACT_AVAILABLE timeout to 60 seconds in order to make it compatible with the current request interval default value (CROSS-1093)

#### Changed

* chore: Update devDependencies
