### PR TITLE
feat(CROSS-1666): read-manifest and write-manifest actions

### DIFF
--- a/.github/workflows/test-component.yml
+++ b/.github/workflows/test-component.yml
@@ -95,33 +95,51 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - id: write1
         name: "write json 1"
         uses: ./manifest-write
         with:
           id: 'w1'
-          json: '{"foo": "bar1"}'
           group: 'test-manifest'
+          json: '{"foo":"bar1"}'
+
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: '{"w1":{"foo":"bar1"}}'
+          actual: ${{ steps.write1.outputs.manifests }}
+
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: '{"include":[{"foo":"bar1"}]}'
+          actual: ${{ steps.write1.outputs.matrix }}
+
       - id: write2
-        name: "Write json 2"
+        name: "write json 2"
         uses: ./manifest-write
         with:
           id: 'w2'
-          json: '{"foo": "bar2"}'
           group: 'test-manifest'
+          json: |
+            {
+              "foo": "bar2"
+            }
+
       - id: write3
         name: "Overwrite json 2"
         uses: ./manifest-write
         with:
           id: 'w2'
-          json: '{"foo": "bar2"}'
           group: 'test-manifest'
+          json: '{"foo": "bar-overwrite-2"}'
+
       - id: write-standalone
-        name: "Launch write-secret action"
+        name: "standalone manifest-write"
         uses: ./manifest-write
         with:
-          id: 'w1'
-          json: '{"foo": "bar"}'
+          id: 's1'
+          json: '{"standalone": true}'
+
   test-component-manifest-read:
     runs-on: ${{ vars.JOBS_RUNNER }}
     needs:
@@ -130,14 +148,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - id: read-test-manifest
+      - id: read
         name: Read test manifest
         uses: ./manifest-read
         with:
           group: 'test-manifest'
 
-      - id: read-stanalone
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: '{"w1":{"foo":"bar1"},"w2":{"foo":"bar-overwrite-2"}}'
+          actual: ${{ steps.read.outputs.manifests }}
+
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: '{"include":[{"foo":"bar1"},{"foo":"bar-overwrite-2"}]}'
+          actual: ${{ steps.read.outputs.matrix }}
+
+      - id: read-standalone
         name: Read standalone manifest
         uses: ./manifest-read
 
-      ## TODO: Add assertions
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: '{"s1":{"standalone":true}}'
+          actual: ${{ steps.read-standalone.outputs.manifests }}
+
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: '{"include":[{"standalone":true}]}'
+          actual: ${{ steps.read-standalone.outputs.matrix }}

--- a/.github/workflows/test-component.yml
+++ b/.github/workflows/test-component.yml
@@ -90,3 +90,54 @@ jobs:
         uses: ./setup-oras
         with:
           version: '1.0.0'
+  test-component-manifest-write:
+    runs-on: ${{ vars.JOBS_RUNNER }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - id: write1
+        name: "write json 1"
+        uses: ./manifest-write
+        with:
+          id: 'w1'
+          json: '{"foo": "bar1"}'
+          group: 'test-manifest'
+      - id: write2
+        name: "Write json 2"
+        uses: ./manifest-write
+        with:
+          id: 'w2'
+          json: '{"foo": "bar2"}'
+          group: 'test-manifest'
+      - id: write3
+        name: "Overwrite json 2"
+        uses: ./manifest-write
+        with:
+          id: 'w2'
+          json: '{"foo": "bar2"}'
+          group: 'test-manifest'
+      - id: write-standalone
+        name: "Launch write-secret action"
+        uses: ./manifest-write
+        with:
+          id: 'w1'
+          json: '{"foo": "bar"}'
+  test-component-manifest-read:
+    runs-on: ${{ vars.JOBS_RUNNER }}
+    needs:
+      - test-component-manifest-write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - id: read-test-manifest
+        name: Read test manifest
+        uses: ./manifest-read
+        with:
+          group: 'test-manifest'
+
+      - id: read-stanalone
+        name: Read standalone manifest
+        uses: ./manifest-read
+
+      ## TODO: Add assertions

--- a/manifest-read/README.md
+++ b/manifest-read/README.md
@@ -1,0 +1,140 @@
+# Table of Contents
+<!-- TOC -->
+
+- [Table of Contents](#table-of-contents)
+- [Usage](#usage)
+  - [Versions](#versions)
+  - [Example](#example)
+  - [Inputs](#inputs)
+  - [Outputs](#outputs)
+  - [Debug mode](#debug-mode)
+- [Development](#development)
+  - [Requirements](#requirements)
+  - [Branching model](#branching-model)
+  - [Component tests](#component-tests)
+  - [Release](#release)
+
+<!-- /TOC -->
+
+# Usage
+
+GitHub actions have an issue about [referencing all outputs of a matrix](https://github.com/orgs/community/discussions/17245). If there is a job that runs multiple times with `strategy.matrix` only the latest iteration's output available for reference in other jobs.
+
+To save outputs of all iterations we need to write them to an GitHub Artifact and read them in another job.
+It also allows us to save manifests from unrelated jobs when [reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
+
+We implement a workaround with two GitHub Actions:
+
+- [manifest-write](../): This action writes the manifest file to the repository.
+- [manifest-read](./): This action reads the manifest file from the repository.
+
+Each time the `manifest-write` action is executed, it will save the provided manifest in GitHub Artifacts with an specific name. The `manifest-read` action will read that GitHub Artifact and unroll all the manifest it contains.
+
+## Versions
+
+To know more about how this action is versioned, read the monorepo [README](../README.md#versions).
+
+## Example
+
+Example of usage in a component repository:
+
+```yaml
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: ["frontend", "backend"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Do some work with the matrix.component, like publish to a docker registry
+
+      # Write for matrix outputs
+      - name: Save publish manifest
+        uses: Telefonica/cross-platform-actions/manifest-write@{BRANCH_NAME|VERSION}
+        with:
+          # Identify the matrix step
+          id: ${{ matrix.module }}
+          # Group the manifest for later retrieval. Optional, default is 'manifests'
+          group: publish-manifests
+          json: |
+            {
+              "name": "${{ matrix.component }}",
+              "repository": "docker.io/my-org/${{ matrix.component }}",
+              "version": 1.0.0",
+              "type": "docker"
+            }
+
+  # Read all manifests
+  manifest:
+    runs-on: ubuntu-latest
+    needs: [publish]
+    steps:
+      # Read all manifests previously saved
+      - name: Read published manifest
+        id: manifest
+        uses: Telefonica/cross-platform-actions/manifest-read@{BRANCH_NAME|VERSION}
+        with:
+          group: publish-manifests
+
+      - name: Print manifest
+        run: |
+          echo "${{ steps.manifest.outputs.manifests }}"
+
+```
+
+## Inputs
+
+- `id`: The manifest identifier. It is used to identify the manifest in the group. It is recommended to use the matrix variable that identifies the step.
+- `group`: The group where the manifest will be saved. Optional, defaults to `manifests`.
+- `json`: The manifest in JSON format serialized as a string. It must be a valid JSON.
+
+## Outputs
+
+- `manifests` - Manifests indexed by id. It is a JSON object where the key is the id and the value is the provided JSON manifest. It is useful to read all the manifests in a job. For example:
+```json
+{
+  "id1": { "name": "my-manifest-1" },
+  "id2": { "name": "my-manifest-2" }
+}
+```
+
+- `matrix`: manifests ready to be used in a matrix as an input.
+```json
+{
+  "include" : [
+    { "name": "my-manifest-1" },
+    { "name": "my-manifest-2" },
+  ]
+}
+```
+```yml
+strategy:
+  matrix: ${{ steps.manifest.outputs.matrix }}
+```
+
+## Debug mode
+
+To enable the debug mode add a repository variable named `ACTIONS_STEP_DEBUG` and set its value to `true`. Debug mode is more verbose and it shows the response of the requests done to the github API.
+
+# Development
+
+## Requirements
+
+No dependencies. Coded as a composite action with inline JavaScript.
+
+## Branching model
+
+This repository uses the trunk-based development branching model. The `main` branch is the main branch (surprise! 😜), and it must be always deployable. All the changes are done in feature branches, and they are merged into `main` using pull requests.
+
+> Note: Even when the main branch should be always deployable, before [declaring a formal release](#release) it may be necessary to perform some manual steps, like updating the changelog or the version number. So, it is recommended to use a release branch to prepare the release.
+
+## Component tests
+
+Component tests are executed in a real environment, using the GitHub Actions Runner.
+
+## Release
+
+Read the monorepo [README](../README.md#release) to know how to release the monorepo, which automatically releases a new version of this action too.

--- a/manifest-read/action.yml
+++ b/manifest-read/action.yml
@@ -49,12 +49,12 @@ runs:
             manifests: Object.fromEntries(manifests),
           };
 
-          core.setOutput('matrix', result.matrix);
-          core.startGroup('matrix');
-          console.log(JSON.stringify(result.matrix, null, 2));
-          core.endGroup();
-
           core.setOutput('manifests', result.manifests);
           core.startGroup('manifests');
           console.log(JSON.stringify(result.manifests, null, 2));
+          core.endGroup();
+
+          core.setOutput('matrix', result.matrix);
+          core.startGroup('matrix');
+          console.log(JSON.stringify(result.matrix, null, 2));
           core.endGroup();

--- a/manifest-read/action.yml
+++ b/manifest-read/action.yml
@@ -1,0 +1,60 @@
+name: Loads the manifest
+description: Loads the manifests written by manifest-write
+
+inputs:
+  group:
+    required: false
+    description: The group of manifests. Consolidated as the artifact name in GitHub
+    default: manifests
+
+outputs:
+  manifests:
+    description: "manifests indexed by id"
+    value: ${{ steps.manifest.outputs.manifests }}
+  matrix:
+    description: "manifests ready to be used in a matrix"
+    value: ${{ steps.manifest.outputs.matrix }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@v3
+      id: download
+      with:
+        name:  ${{ inputs.group }}
+        path: ${{ runner.temp }}/${{ inputs.group }}
+
+    - uses: actions/github-script@v6
+      id: manifest
+      env:
+        DOWNLOAD_PATH: ${{ steps.download.outputs.download-path }}
+      with:
+        script: |
+          const { readFile } = require('fs/promises');
+          const path = require('path');
+
+          const manifests = new Map();
+          const globber = await glob.create(path.join(process.env.DOWNLOAD_PATH, '*.json'));
+
+          for await (const file of globber.globGenerator()) {
+            const manifest = JSON.parse(await readFile(file));
+            const id = path.parse(file).name;
+            manifests.set(id, manifest);
+          }
+
+          const result = {
+            matrix: {
+              include: Array.from(manifests.values()),
+            },
+            manifests: Object.fromEntries(manifests),
+          };
+
+          core.setOutput('matrix', result.matrix);
+          core.startGroup('matrix');
+          console.log(JSON.stringify(result.matrix, null, 2));
+          core.endGroup();
+
+          core.setOutput('manifests', result.manifests);
+          core.startGroup('manifests');
+          console.log(JSON.stringify(result.manifests, null, 2));
+          core.endGroup();

--- a/manifest-write/README.md
+++ b/manifest-write/README.md
@@ -1,0 +1,138 @@
+# Table of Contents
+<!-- TOC -->
+
+- [Table of Contents](#table-of-contents)
+- [Usage](#usage)
+  - [Versions](#versions)
+  - [Example](#example)
+  - [Inputs](#inputs)
+  - [Outputs](#outputs)
+  - [Debug mode](#debug-mode)
+- [Development](#development)
+  - [Requirements](#requirements)
+  - [Branching model](#branching-model)
+  - [Component tests](#component-tests)
+  - [Release](#release)
+
+<!-- /TOC -->
+
+# Usage
+
+GitHub actions have an issue about [referencing all outputs of a matrix](https://github.com/orgs/community/discussions/17245). If there is a job that runs multiple times with `strategy.matrix` only the latest iteration's output available for reference in other jobs.
+
+To save outputs of all iterations we need to write them to an GitHub Artifact and read them in another job.
+It also allows us to save manifests from unrelated jobs when [reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
+
+We implement a workaround with two GitHub Actions:
+
+- [manifest-write](./): This action writes the manifest file to the repository.
+- [manifest-read](../): This action reads the manifest file from the repository.
+
+Each time the `manifest-write` action is executed, it will save the provided manifest in GitHub Artifacts with an specific name. The `manifest-read` action will read that GitHub Artifact and unroll all the manifest it contains.
+
+## Versions
+
+To know more about how this action is versioned, read the monorepo [README](../README.md#versions).
+
+## Example
+
+Example of usage in a component repository:
+
+```yaml
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: ["frontend", "backend"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Do some work with the matrix.component, like publish to a docker registry
+
+      # Write for matrix outputs
+      - name: Save publish manifest
+        uses: Telefonica/cross-platform-actions/manifest-write@{BRANCH_NAME|VERSION}
+        with:
+          # Identify the matrix step
+          id: ${{ matrix.module }}
+          # Group the manifest for later retrieval. Optional, default is 'manifests'
+          group: publish-manifests
+          json: |
+            {
+              "name": "${{ matrix.component }}",
+              "repository": "docker.io/my-org/${{ matrix.component }}",
+              "version": 1.0.0",
+              "type": "docker"
+            }
+
+  # Read all manifests
+  manifest:
+    runs-on: ubuntu-latest
+    needs: [publish]
+    steps:
+      # Read all manifests previously saved
+      - name: Read published manifest
+        id: manifest
+        uses: Telefonica/cross-platform-actions/manifest-read@{BRANCH_NAME|VERSION}
+        with:
+          group: publish-manifests
+
+      - name: Print manifest
+        run: |
+          echo "${{ steps.manifest.outputs.manifests }}"
+
+```
+
+## Inputs
+
+- `id`: The manifest identifier. It is used to identify the manifest in the group. It is recommended to use the matrix variable that identifies the step.
+- `group`: The group where the manifest will be saved. Optional, defaults to `manifests`.
+- `json`: The manifest in JSON format serialized as a string. It must be a valid JSON.
+
+## Outputs
+
+- `manifests` - Manifests indexed by id. It is a JSON object where the key is the id and the value is the provided JSON manifest. It is useful to read all the manifests in a job. For example:
+```json
+{
+  "id1": { "name": "my-manifest-1" }
+}
+```
+
+- `matrix`: manifests ready to be used in a matrix as an input.
+```json
+{
+  "include" : [
+    { "name": "my-manifest-1" }
+  ]
+}
+```
+```yml
+strategy:
+  matrix: ${{ steps.manifest.outputs.matrix }}
+```
+
+## Debug mode
+
+To enable the debug mode add a repository variable named `ACTIONS_STEP_DEBUG` and set its value to `true`. Debug mode is more verbose and it shows the response of the requests done to the github API.
+
+# Development
+
+## Requirements
+
+No dependencies. Coded as a composite action with inline JavaScript.
+
+## Branching model
+
+This repository uses the trunk-based development branching model. The `main` branch is the main branch (surprise! 😜), and it must be always deployable. All the changes are done in feature branches, and they are merged into `main` using pull requests.
+
+> Note: Even when the main branch should be always deployable, before [declaring a formal release](#release) it may be necessary to perform some manual steps, like updating the changelog or the version number. So, it is recommended to use a release branch to prepare the release.
+
+## Component tests
+
+Component tests are executed in a real environment, using the GitHub Actions Runner.
+
+## Release
+
+Read the monorepo [README](../README.md#release) to know how to release the monorepo, which automatically releases a new version of this action too.

--- a/manifest-write/action.yml
+++ b/manifest-write/action.yml
@@ -1,0 +1,87 @@
+name: Save a manifest
+description: Saves a manifest in the artifacts for later retrieval
+inputs:
+  id:
+    required: true
+    description: Artifact id
+  json:
+    required: true
+    description: JSON for the artifact as a string
+  group:
+    required: false
+    description: The group of manifests. Consolidated as the artifact name in GitHub
+    default: manifests
+
+outputs:
+  manifests:
+    description: "manifests indexed by id"
+    value: ${{ steps.manifest.outputs.manifests }}
+  matrix:
+    description: "manifests ready to be used in a matrix"
+    value: ${{ steps.manifest.outputs.matrix }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@v6
+      id: manifest
+      env:
+        TEMP_DIR: ${{ runner.temp }}
+      with:
+        script: |
+          const { writeFile } = require('fs/promises');
+          const path = require('path');
+
+          const id = `${{ inputs.id }}`;
+          const json = `${{ inputs.json }}`;
+          const group = `${{ inputs.group }}` || 'manifests';
+
+          if (isEmpty(id)) {
+            core.setFailed(`'id' is mandatory`);
+            return;
+          }
+          if (isEmpty(json)) {
+            core.setFailed(`'json' is mandatory`);
+            return;
+          }
+
+          let manifest;
+          try {
+            manifest = JSON.parse(json);
+          } catch (error) {
+            core.setFailed(`'json' should be valid JSON`);
+            return;
+          }
+
+          const tempPath = path.join(process.env.TEMP_DIR, group);
+          await io.mkdirP(tempPath);
+          await writeFile(path.join(tempPath, `${id}.json`), JSON.stringify(manifest));
+
+          const manifests = new Map();
+          manifests.set(id, manifest);
+
+          const result = {
+            matrix: {
+              include: Array.from(manifests.values()),
+            },
+            manifests: Object.fromEntries(manifests),
+          };
+
+          core.setOutput('matrix', result.matrix);
+          core.startGroup('matrix');
+          console.log(JSON.stringify(result.matrix, null, 2));
+          core.endGroup();
+
+          core.setOutput('manifests', result.manifests);
+          core.startGroup('manifests');
+          console.log(JSON.stringify(result.manifests, null, 2));
+          core.endGroup();
+
+          function isEmpty(value) {
+            return value == null || value.trim() === '';
+          }
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.group }}
+        path: ${{ runner.temp }}/${{ inputs.group }}/*.json

--- a/manifest-write/action.yml
+++ b/manifest-write/action.yml
@@ -23,18 +23,27 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/github-script@v6
+    - name: Generate UUID
+      id: generate-uuid
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const crypto = require('crypto');
+          core.setOutput('uuid', crypto.randomUUID());
+
+    - name: Write Manifest
+      uses: actions/github-script@v6
       id: manifest
       env:
-        TEMP_DIR: ${{ runner.temp }}
+        TEMP_DIR: ${{ runner.temp }}/${{ steps.generate-uuid.outputs.uuid }}
       with:
         script: |
           const { writeFile } = require('fs/promises');
           const path = require('path');
+          const crypto = require('crypto');
 
           const id = `${{ inputs.id }}`;
           const json = `${{ inputs.json }}`;
-          const group = `${{ inputs.group }}` || 'manifests';
 
           if (isEmpty(id)) {
             core.setFailed(`'id' is mandatory`);
@@ -53,9 +62,8 @@ runs:
             return;
           }
 
-          const tempPath = path.join(process.env.TEMP_DIR, group);
-          await io.mkdirP(tempPath);
-          await writeFile(path.join(tempPath, `${id}.json`), JSON.stringify(manifest));
+          await io.mkdirP(process.env.TEMP_DIR);
+          await writeFile(path.join(process.env.TEMP_DIR, `${id}.json`), JSON.stringify(manifest));
 
           const manifests = new Map();
           manifests.set(id, manifest);
@@ -67,14 +75,14 @@ runs:
             manifests: Object.fromEntries(manifests),
           };
 
-          core.setOutput('matrix', result.matrix);
-          core.startGroup('matrix');
-          console.log(JSON.stringify(result.matrix, null, 2));
-          core.endGroup();
-
           core.setOutput('manifests', result.manifests);
           core.startGroup('manifests');
           console.log(JSON.stringify(result.manifests, null, 2));
+          core.endGroup();
+
+          core.setOutput('matrix', result.matrix);
+          core.startGroup('matrix');
+          console.log(JSON.stringify(result.matrix, null, 2));
           core.endGroup();
 
           function isEmpty(value) {
@@ -84,4 +92,4 @@ runs:
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.group }}
-        path: ${{ runner.temp }}/${{ inputs.group }}/*.json
+        path: ${{ runner.temp }}/${{ steps.generate-uuid.outputs.uuid }}/*.json

--- a/support/dictionaries/people.txt
+++ b/support/dictionaries/people.txt
@@ -1,1 +1,2 @@
 ismtabo
+filipstefansson

--- a/support/dictionaries/tech-terms.txt
+++ b/support/dictionaries/tech-terms.txt
@@ -6,3 +6,4 @@ keypair
 env
 oras
 cli
+globber


### PR DESCRIPTION
# CROSS-1666 - manifest-write and manifest-read

## Description

GitHub actions have an issue about [referencing all outputs of a matrix](https://github.com/orgs/community/discussions/17245). If there is a job that runs multiple times with `strategy.matrix` only the latest iteration's output available for reference in other jobs.

To save outputs of all iterations we need to write them to an GitHub Artifact and read them in another job.
It also allows us to save manifests from unrelated jobs when [reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)

We implement a workaround with two GitHub Actions:

- `manifest-write`: This action writes the manifest file to the repository.
- `manifest-read`: This action reads the manifest file from the repository.

Each time the `manifest-write` action is executed, it will save the provided manifest in GitHub Artifacts with an specific name. The `manifest-read` action will read that GitHub Artifact and unroll all the manifest it contains.


Due to its simplicity, is implemented as an inline javascript using `github-script` in a composite action, allowing reuse of `upload-artifact` action.
component test are implemented directly in workflows

## Check list

* [x] Unit tests have been executed locally
* [x] Build has been executed locally
* [x] The dist folder has been updated
* [x] The documentation has been updated

