### PR TITLE
fix(CROSS-1686): mask secrets in citadel-login

### DIFF
--- a/citadel-login/action.yml
+++ b/citadel-login/action.yml
@@ -8,6 +8,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Mask Secrets
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const registriesInput = core.getInput('citadel-registries') || '{}';
+
+          try {
+            const registries = JSON.parse(registriesInput);
+            if (registries.oci?.dev?.password){
+              core.setSecret(registries.oci.dev.password);
+            }
+            if (registries.oci?.pro?.password){
+              core.setSecret(registries.oci.pro.password);
+            }
+          }
+
     - name: Login to OCI dev registry
       uses: docker/login-action@v2
       if: fromJSON(inputs.citadel-registries).oci.dev


### PR DESCRIPTION

# CROSS-1686 -citadel-login: secrets are not masked in GitHub Actions UI

## Description

Add a mask to avoid showing the citadel secrets in GitHub Actions logs ui


## Check list

* [x] Unit tests have been executed locally
* [x] Build has been executed locally
* [x] The dist folder has been updated
* [x] The documentation has been updated
